### PR TITLE
DEV-845: add cookie consent banner

### DIFF
--- a/firebird/skeleton.xsl
+++ b/firebird/skeleton.xsl
@@ -77,9 +77,9 @@
         
         <xsl:call-template name="debug-messages" />
 
+        <hathi-cookie-consent-banner></hathi-cookie-consent-banner>
         <xsl:call-template name="skip-to-main-link" />
 
-        <hathi-acceptable-use-banner></hathi-acceptable-use-banner>
         <div id="root">
           <xsl:call-template name="build-root-attributes" />
 


### PR DESCRIPTION
Removed acceptable use banner and added cookie consent banner component. Moved it above the skip links for accessibility purposes.

There's not really anything here to review, but I will need some guidance on deploying this since it's a submodule (`common-web`) for `ls` and `mb`.